### PR TITLE
Implementa sistema de ordens de serviço telecom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+service_orders.db
+app/storage/
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,61 @@
-# os-system
-sistema de ordem de serviço
+# Sistema de Ordens de Serviço Telecom
+
+Aplicação FastAPI para gestão de ordens de serviço de instalação telecom com controle de equipes, técnicos e períodos.
+
+## Requisitos
+
+- Python 3.11+
+- pip
+
+## Instalação
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Uso
+
+```bash
+uvicorn app.main:app --reload
+```
+
+A aplicação cria automaticamente:
+
+- Usuário admin padrão `admin`/`admin` (altere a senha em produção).
+- Equipes "Equipe 1" até "Equipe 4".
+
+## Endpoints principais
+
+Autenticação via OAuth2 Password (Bearer Token). Obtenha token em `/auth/token` informando usuário e senha.
+
+### Usuários
+
+- `POST /users` (admin): cria usuários com papéis `admin`, `support` ou `technician`.
+- `GET /users` (admin/suporte): lista usuários cadastrados.
+
+### Equipes
+
+- `GET /teams` (admin/suporte): lista equipes.
+- `POST /teams` (admin): cria novas equipes.
+
+### Períodos
+
+- `POST /periods` (admin/suporte): cadastra período personalizado.
+- `GET /periods` (admin/suporte): lista períodos existentes.
+
+### Ordens de serviço
+
+- `POST /orders` (admin/suporte): cria ordem de serviço individual.
+- `POST /orders/import` (admin/suporte): importa várias ordens via CSV com cabeçalhos `nome,endereco,id_instalacao,plano,data_agendamento` (data no formato `YYYY-MM-DD`).
+- `GET /orders` (todos): lista ordens filtrando por período, intervalo de datas e equipe. Técnicos visualizam apenas as suas ordens.
+- `GET /orders/{id}` (todos): detalhes da ordem (tecnicos apenas as próprias).
+- `PATCH /orders/{id}` (todos): atualização de status, equipe, técnico e data. Técnicos só podem marcar como `in_progress` ou `completed`.
+- `POST /orders/{id}/observations` (todos): adiciona observações à ordem.
+- `POST /orders/{id}/photos` (todos): upload de fotos da instalação (salvas em `app/storage/order_{id}/`).
+- `DELETE /orders/{id}` (admin/suporte): remove ordem.
+
+## Testes rápidos
+
+Com o servidor em execução, utilize o Swagger UI disponível em `http://localhost:8000/docs` para explorar e testar todos os recursos.

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from sqlalchemy.orm import Session
+
+from .database import get_session
+from .models import User
+from .schemas import TokenData
+
+SECRET_KEY = "change-me-in-production"
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 8
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+
+def get_user_by_username(session: Session, username: str) -> Optional[User]:
+    return session.query(User).filter(User.username == username).one_or_none()
+
+
+async def get_current_user(
+    token: str = Depends(oauth2_scheme), session: Session = Depends(get_session)
+) -> User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str | None = payload.get("sub")
+        if username is None:
+            raise credentials_exception
+        token_data = TokenData(username=username)
+    except JWTError as exc:  # pragma: no cover - security catch
+        raise credentials_exception from exc
+
+    user = get_user_by_username(session, token_data.username)
+    if user is None or not user.is_active:
+        raise credentials_exception
+    return user
+
+
+def require_roles(*roles: str):
+    def role_checker(user: User = Depends(get_current_user)) -> User:
+        if user.role.value not in roles:
+            raise HTTPException(status_code=403, detail="Operation not permitted")
+        return user
+
+    return role_checker

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = "sqlite:///./service_orders.db"
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}, future=True, echo=False
+)
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)
+
+Base = declarative_base()
+
+
+@contextmanager
+def session_scope() -> Generator:
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def get_session() -> Generator:
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,385 @@
+from __future__ import annotations
+
+import os
+from datetime import date, datetime
+from pathlib import Path
+from typing import List, Optional
+
+from fastapi import (
+    Depends,
+    FastAPI,
+    File,
+    HTTPException,
+    UploadFile,
+    status,
+)
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy.orm import Session
+
+from . import models, schemas
+from .auth import (
+    create_access_token,
+    get_current_user,
+    get_password_hash,
+    require_roles,
+    verify_password,
+)
+from .database import Base, engine, get_session, session_scope
+from .models import ServiceOrder, ServiceOrderStatus, Team, User, UserRole
+from .schemas import (
+    ObservationCreate,
+    ObservationRead,
+    PeriodCreate,
+    PeriodRead,
+    ServiceOrderCreate,
+    ServiceOrderRead,
+    ServiceOrderUpdate,
+    TeamCreate,
+    TeamRead,
+    Token,
+    UserCreate,
+    UserRead,
+)
+from .utils import parse_orders_csv
+
+app = FastAPI(title="Sistema de Ordens de Serviço Telecom")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+UPLOAD_DIR = Path(os.getenv("UPLOAD_DIR", Path(__file__).resolve().parent / "storage"))
+UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+
+
+@app.on_event("startup")
+def startup() -> None:
+    Base.metadata.create_all(bind=engine)
+    with session_scope() as session:
+        models.ensure_default_teams(session)
+        models.ensure_admin_user(session, "admin", get_password_hash("admin"))
+
+
+@app.post("/auth/token", response_model=Token)
+def login(
+    form_data: OAuth2PasswordRequestForm = Depends(), session: Session = Depends(get_session)
+):
+    user = session.query(User).filter(User.username == form_data.username).one_or_none()
+    if not user or not verify_password(form_data.password, user.hashed_password):
+        raise HTTPException(status_code=400, detail="Usuário ou senha inválidos")
+    if not user.is_active:
+        raise HTTPException(status_code=400, detail="Usuário desativado")
+
+    access_token = create_access_token(data={"sub": user.username})
+    return Token(access_token=access_token)
+
+
+@app.post("/users", response_model=UserRead, status_code=status.HTTP_201_CREATED)
+def create_user(
+    payload: UserCreate,
+    session: Session = Depends(get_session),
+    _: User = Depends(require_roles(UserRole.admin.value)),
+):
+    if session.query(User).filter(User.username == payload.username).first():
+        raise HTTPException(status_code=400, detail="Usuário já existe")
+
+    if payload.role == UserRole.technician and payload.team_id is None:
+        raise HTTPException(
+            status_code=400, detail="Técnicos precisam estar associados a uma equipe"
+        )
+
+    user = User(
+        username=payload.username,
+        hashed_password=get_password_hash(payload.password),
+        role=payload.role,
+        team_id=payload.team_id,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+@app.get("/users", response_model=List[UserRead])
+def list_users(
+    session: Session = Depends(get_session),
+    _: User = Depends(require_roles(UserRole.admin.value, UserRole.support.value)),
+):
+    return session.query(User).all()
+
+
+@app.post("/teams", response_model=TeamRead, status_code=status.HTTP_201_CREATED)
+def create_team(
+    payload: TeamCreate,
+    session: Session = Depends(get_session),
+    _: User = Depends(require_roles(UserRole.admin.value)),
+):
+    team = Team(name=payload.name)
+    session.add(team)
+    session.commit()
+    session.refresh(team)
+    return team
+
+
+@app.get("/teams", response_model=List[TeamRead])
+def list_teams(
+    session: Session = Depends(get_session),
+    _: User = Depends(require_roles(UserRole.admin.value, UserRole.support.value)),
+):
+    return session.query(Team).all()
+
+
+@app.post("/periods", response_model=PeriodRead, status_code=status.HTTP_201_CREATED)
+def create_period(
+    payload: PeriodCreate,
+    session: Session = Depends(get_session),
+    _: User = Depends(require_roles(UserRole.admin.value, UserRole.support.value)),
+):
+    period = models.Period(**payload.model_dump())
+    session.add(period)
+    session.commit()
+    session.refresh(period)
+    return period
+
+
+@app.get("/periods", response_model=List[PeriodRead])
+def list_periods(
+    session: Session = Depends(get_session),
+    _: User = Depends(require_roles(UserRole.admin.value, UserRole.support.value)),
+):
+    return session.query(models.Period).order_by(models.Period.start_date).all()
+
+
+@app.post("/orders", response_model=ServiceOrderRead, status_code=status.HTTP_201_CREATED)
+def create_order(
+    payload: ServiceOrderCreate,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(
+        require_roles(UserRole.admin.value, UserRole.support.value)
+    ),
+):
+    if (
+        session.query(ServiceOrder)
+        .filter(ServiceOrder.installation_id == payload.installation_id)
+        .first()
+    ):
+        raise HTTPException(status_code=400, detail="ID de instalação já cadastrado")
+
+    order = ServiceOrder(**payload.model_dump())
+    if order.technician_id:
+        technician = session.get(User, order.technician_id)
+        if not technician or technician.role != UserRole.technician:
+            raise HTTPException(status_code=400, detail="Técnico inválido")
+    if order.team_id:
+        team = session.get(Team, order.team_id)
+        if not team:
+            raise HTTPException(status_code=400, detail="Equipe inválida")
+
+    session.add(order)
+    session.commit()
+    session.refresh(order)
+    return order
+
+
+@app.post("/orders/import", response_model=List[ServiceOrderRead])
+def import_orders(
+    file: UploadFile = File(...),
+    session: Session = Depends(get_session),
+    _: User = Depends(require_roles(UserRole.admin.value, UserRole.support.value)),
+):
+    if file.content_type not in {"text/csv", "application/vnd.ms-excel"}:
+        raise HTTPException(status_code=400, detail="Envie um arquivo CSV")
+
+    orders_data = parse_orders_csv(file.file.read())
+    created_orders: List[ServiceOrder] = []
+    for order_payload in orders_data:
+        if (
+            session.query(ServiceOrder)
+            .filter(ServiceOrder.installation_id == order_payload.installation_id)
+            .first()
+        ):
+            continue
+        order = ServiceOrder(**order_payload.model_dump())
+        session.add(order)
+        created_orders.append(order)
+    session.commit()
+    for order in created_orders:
+        session.refresh(order)
+    return created_orders
+
+
+def _apply_order_filters(
+    query,
+    start_date: Optional[date],
+    end_date: Optional[date],
+    period_id: Optional[int],
+    team_id: Optional[int],
+    technician_id: Optional[int],
+):
+    if start_date:
+        query = query.filter(ServiceOrder.scheduled_date >= start_date)
+    if end_date:
+        query = query.filter(ServiceOrder.scheduled_date <= end_date)
+    if period_id:
+        query = query.filter(ServiceOrder.period_id == period_id)
+    if team_id:
+        query = query.filter(ServiceOrder.team_id == team_id)
+    if technician_id:
+        query = query.filter(ServiceOrder.technician_id == technician_id)
+    return query
+
+
+@app.get("/orders", response_model=List[ServiceOrderRead])
+def list_orders(
+    start_date: Optional[date] = None,
+    end_date: Optional[date] = None,
+    period_id: Optional[int] = None,
+    team_id: Optional[int] = None,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    query = session.query(ServiceOrder)
+    if current_user.role == UserRole.technician:
+        query = _apply_order_filters(
+            query.filter(ServiceOrder.technician_id == current_user.id),
+            start_date,
+            end_date,
+            period_id,
+            None,
+            current_user.id,
+        )
+    else:
+        query = _apply_order_filters(query, start_date, end_date, period_id, team_id, None)
+    return query.order_by(ServiceOrder.scheduled_date.desc()).all()
+
+
+@app.get("/orders/{order_id}", response_model=ServiceOrderRead)
+def get_order(
+    order_id: int,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    order = session.get(ServiceOrder, order_id)
+    if not order:
+        raise HTTPException(status_code=404, detail="Ordem não encontrada")
+
+    if current_user.role == UserRole.technician and order.technician_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Sem permissão para visualizar esta ordem")
+    return order
+
+
+@app.patch("/orders/{order_id}", response_model=ServiceOrderRead)
+def update_order(
+    order_id: int,
+    payload: ServiceOrderUpdate,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    order = session.get(ServiceOrder, order_id)
+    if not order:
+        raise HTTPException(status_code=404, detail="Ordem não encontrada")
+
+    if current_user.role == UserRole.technician:
+        allowed_status = {ServiceOrderStatus.in_progress, ServiceOrderStatus.completed}
+        if payload.status and payload.status not in allowed_status:
+            raise HTTPException(status_code=403, detail="Status inválido para técnico")
+        if order.technician_id != current_user.id:
+            raise HTTPException(status_code=403, detail="Sem permissão para alterar esta ordem")
+    elif current_user.role in {UserRole.support, UserRole.admin}:
+        pass
+    else:
+        raise HTTPException(status_code=403, detail="Operação não permitida")
+
+    update_data = payload.model_dump(exclude_unset=True)
+
+    if "technician_id" in update_data and update_data["technician_id"] is not None:
+        tech = session.get(User, update_data["technician_id"])
+        if not tech or tech.role != UserRole.technician:
+            raise HTTPException(status_code=400, detail="Técnico inválido")
+    if "team_id" in update_data and update_data["team_id"] is not None:
+        team = session.get(Team, update_data["team_id"])
+        if not team:
+            raise HTTPException(status_code=400, detail="Equipe inválida")
+
+    for key, value in update_data.items():
+        setattr(order, key, value)
+
+    session.add(order)
+    session.commit()
+    session.refresh(order)
+    return order
+
+
+@app.post("/orders/{order_id}/observations", response_model=ObservationRead)
+def add_observation(
+    order_id: int,
+    payload: ObservationCreate,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    order = session.get(ServiceOrder, order_id)
+    if not order:
+        raise HTTPException(status_code=404, detail="Ordem não encontrada")
+
+    if current_user.role == UserRole.technician and order.technician_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Sem permissão para adicionar observações")
+
+    observation = models.OrderObservation(
+        order_id=order.id, author_id=current_user.id, note=payload.note
+    )
+    session.add(observation)
+    session.commit()
+    session.refresh(observation)
+    return observation
+
+
+@app.post("/orders/{order_id}/photos", response_model=schemas.PhotoRead)
+def upload_photo(
+    order_id: int,
+    file: UploadFile = File(...),
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    order = session.get(ServiceOrder, order_id)
+    if not order:
+        raise HTTPException(status_code=404, detail="Ordem não encontrada")
+
+    if current_user.role == UserRole.technician and order.technician_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Sem permissão para adicionar fotos")
+
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="Arquivo inválido")
+
+    order_dir = UPLOAD_DIR / f"order_{order_id}"
+    order_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    filename = f"{timestamp}_{file.filename.replace(' ', '_')}"
+    file_path = order_dir / filename
+
+    with file_path.open("wb") as buffer:
+        contents = file.file.read()
+        buffer.write(contents)
+
+    photo = models.OrderPhoto(order_id=order.id, file_path=str(file_path))
+    session.add(photo)
+    session.commit()
+    session.refresh(photo)
+    return photo
+
+
+@app.delete("/orders/{order_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_order(
+    order_id: int,
+    session: Session = Depends(get_session),
+    _: User = Depends(require_roles(UserRole.admin.value, UserRole.support.value)),
+):
+    order = session.get(ServiceOrder, order_id)
+    if not order:
+        raise HTTPException(status_code=404, detail="Ordem não encontrada")
+    session.delete(order)
+    session.commit()
+    return None

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import enum
+from datetime import datetime
+from pathlib import Path
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Column,
+    Date,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import relationship
+
+from .database import Base
+
+
+class UserRole(str, enum.Enum):
+    admin = "admin"
+    support = "support"
+    technician = "technician"
+
+
+class Team(Base):
+    __tablename__ = "teams"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), unique=True, nullable=False)
+
+    technicians = relationship("User", back_populates="team")
+    orders = relationship("ServiceOrder", back_populates="team")
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String(50), unique=True, nullable=False, index=True)
+    hashed_password = Column(String(255), nullable=False)
+    role = Column(Enum(UserRole), nullable=False)
+    is_active = Column(Boolean, default=True)
+    team_id = Column(Integer, ForeignKey("teams.id"), nullable=True)
+
+    team = relationship("Team", back_populates="technicians")
+    observations = relationship("OrderObservation", back_populates="author")
+    orders = relationship("ServiceOrder", back_populates="technician")
+
+
+class Period(Base):
+    __tablename__ = "periods"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), nullable=False, unique=True)
+    start_date = Column(Date, nullable=False)
+    end_date = Column(Date, nullable=False)
+
+    __table_args__ = (
+        CheckConstraint("end_date >= start_date", name="ck_period_dates"),
+    )
+
+    orders = relationship("ServiceOrder", back_populates="period")
+
+
+class ServiceOrderStatus(str, enum.Enum):
+    pending = "pending"
+    in_progress = "in_progress"
+    completed = "completed"
+    cancelled = "cancelled"
+
+
+class ServiceOrder(Base):
+    __tablename__ = "service_orders"
+
+    id = Column(Integer, primary_key=True, index=True)
+    customer_name = Column(String(150), nullable=False)
+    address = Column(String(255), nullable=False)
+    installation_id = Column(String(100), nullable=False, index=True)
+    plan = Column(String(100), nullable=False)
+    scheduled_date = Column(Date, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    status = Column(Enum(ServiceOrderStatus), default=ServiceOrderStatus.pending, nullable=False)
+    team_id = Column(Integer, ForeignKey("teams.id"), nullable=True)
+    technician_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    period_id = Column(Integer, ForeignKey("periods.id"), nullable=True)
+
+    team = relationship("Team", back_populates="orders")
+    technician = relationship("User", back_populates="orders")
+    period = relationship("Period", back_populates="orders")
+    observations = relationship(
+        "OrderObservation", back_populates="order", cascade="all, delete-orphan"
+    )
+    photos = relationship("OrderPhoto", back_populates="order", cascade="all, delete-orphan")
+
+    __table_args__ = (
+        UniqueConstraint("installation_id", name="uq_installation_id"),
+    )
+
+
+class OrderObservation(Base):
+    __tablename__ = "order_observations"
+
+    id = Column(Integer, primary_key=True, index=True)
+    order_id = Column(Integer, ForeignKey("service_orders.id"), nullable=False)
+    author_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    note = Column(Text, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    order = relationship("ServiceOrder", back_populates="observations")
+    author = relationship("User", back_populates="observations")
+
+
+class OrderPhoto(Base):
+    __tablename__ = "order_photos"
+
+    id = Column(Integer, primary_key=True, index=True)
+    order_id = Column(Integer, ForeignKey("service_orders.id"), nullable=False)
+    file_path = Column(String(255), nullable=False)
+    uploaded_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    order = relationship("ServiceOrder", back_populates="photos")
+
+    @property
+    def filename(self) -> str:
+        return Path(self.file_path).name
+
+
+def ensure_default_teams(session) -> None:
+    existing = {team.name for team in session.query(Team).all()}
+    for idx in range(1, 5):
+        name = f"Equipe {idx}"
+        if name not in existing:
+            session.add(Team(name=name))
+
+
+def ensure_admin_user(session, username: str, password_hash: str) -> None:
+    user = session.query(User).filter(User.username == username).one_or_none()
+    if user is None:
+        session.add(
+            User(username=username, hashed_password=password_hash, role=UserRole.admin)
+        )

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .models import ServiceOrderStatus, UserRole
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class TokenData(BaseModel):
+    username: str | None = None
+
+
+class UserBase(BaseModel):
+    username: str
+    role: UserRole
+    team_id: Optional[int] = None
+
+
+class UserCreate(BaseModel):
+    username: str = Field(..., min_length=3, max_length=50)
+    password: str = Field(..., min_length=6)
+    role: UserRole
+    team_id: Optional[int] = None
+
+
+class UserRead(UserBase):
+    id: int
+    is_active: bool
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PeriodBase(BaseModel):
+    name: str
+    start_date: date
+    end_date: date
+
+
+class PeriodCreate(PeriodBase):
+    pass
+
+
+class PeriodRead(PeriodBase):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ObservationRead(BaseModel):
+    id: int
+    author_id: int
+    note: str
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PhotoRead(BaseModel):
+    id: int
+    file_path: str
+    filename: str
+    uploaded_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ServiceOrderBase(BaseModel):
+    customer_name: str
+    address: str
+    installation_id: str
+    plan: str
+    scheduled_date: date
+    team_id: Optional[int] = None
+    technician_id: Optional[int] = None
+    period_id: Optional[int] = None
+
+
+class ServiceOrderCreate(ServiceOrderBase):
+    pass
+
+
+class ServiceOrderUpdate(BaseModel):
+    status: Optional[ServiceOrderStatus] = None
+    technician_id: Optional[int] = None
+    team_id: Optional[int] = None
+    scheduled_date: Optional[date] = None
+    period_id: Optional[int] = None
+
+
+class ServiceOrderRead(ServiceOrderBase):
+    id: int
+    status: ServiceOrderStatus
+    created_at: datetime
+    observations: List[ObservationRead] = []
+    photos: List[PhotoRead] = []
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ObservationCreate(BaseModel):
+    note: str = Field(..., min_length=1)
+
+
+class TeamBase(BaseModel):
+    name: str
+
+
+class TeamCreate(TeamBase):
+    pass
+
+
+class TeamRead(TeamBase):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import csv
+import io
+from datetime import datetime
+from typing import Iterable, List, Sequence
+
+from .schemas import ServiceOrderCreate
+
+EXPECTED_HEADERS = {
+    "nome": "customer_name",
+    "endereco": "address",
+    "id_instalacao": "installation_id",
+    "plano": "plan",
+    "data_agendamento": "scheduled_date",
+}
+
+
+def normalize_header(header: str) -> str:
+    return header.strip().lower().replace(" ", "_")
+
+
+def parse_orders_csv(data: bytes) -> List[ServiceOrderCreate]:
+    """Parse a CSV file containing service orders.
+
+    Expected headers (case insensitive): nome, endereco, id_instalacao, plano, data_agendamento
+    """
+
+    buffer = io.StringIO(data.decode("utf-8-sig"))
+    reader = csv.DictReader(buffer)
+    if not reader.fieldnames:
+        raise ValueError("Arquivo CSV sem cabeçalho")
+
+    columns = {normalize_header(name): name for name in reader.fieldnames}
+
+    missing_columns = [label for label in EXPECTED_HEADERS if label not in columns]
+    if missing_columns:
+        raise ValueError(
+            "Colunas obrigatórias ausentes no arquivo: " + ", ".join(missing_columns)
+        )
+
+    orders: List[ServiceOrderCreate] = []
+    for row in reader:
+        if not any(value.strip() for value in row.values() if value):
+            continue
+        kwargs = {}
+        for header, field_name in EXPECTED_HEADERS.items():
+            raw_value = row[columns[header]].strip()
+            if header == "data_agendamento":
+                try:
+                    value = datetime.strptime(raw_value, "%Y-%m-%d").date()
+                except ValueError as exc:
+                    raise ValueError(
+                        f"Data inválida '{raw_value}' para a ordem {row}"
+                    ) from exc
+            else:
+                value = raw_value
+            kwargs[field_name] = value
+        orders.append(ServiceOrderCreate(**kwargs))
+    return orders

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.110.0
+uvicorn[standard]==0.27.1
+SQLAlchemy==2.0.29
+passlib[bcrypt]==1.7.4
+python-multipart==0.0.9
+pydantic[email]==2.7.1
+python-jose[cryptography]==3.3.0


### PR DESCRIPTION
## Summary
- adiciona backend FastAPI com autenticação e papéis para administrar ordens de serviço telecom
- implementa CRUD de usuários, equipes, períodos e ordens com importação CSV, observações e fotos
- documenta instalação e uso via README atualizado

## Testing
- `python -m compileall app`


------
https://chatgpt.com/codex/tasks/task_e_68d1aec5f9588324a5163011dc9dcb7a